### PR TITLE
add `not-initial` option to canEdit on fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ But all these options are available:
     field1: { // all other key names match the field name from the API
         name: String,
         canView: Boolean | Function that returns Boolean,
-        canEdit: "initial" | "empty" | Boolean | Function that returns Boolean,
+        canEdit: "initial" | "not-initial" | "empty" | Boolean | Function that returns Boolean,
         canViewList: Boolean,
         required: Boolean,
         type: String, any valid HTML input type,
@@ -172,7 +172,7 @@ Whether the field can be viewed. The most common reason this would be set to `fa
 
 *"initial", "empty", Boolean, Function that returns Boolean* | Default: true
 
-Whether the field can be edited. When set to `false` an `rh-field` will be disabled. When `"initial"` the field is only editable during `rh-form` record creation. When `"empty"` the field is only editable if it starts out empty when editing.
+Whether the field can be edited. When set to `false` an `rh-field` will be disabled. When `"initial"` the field is only editable during `rh-form` record creation, and the opposite for `"not-initial"`. When `"empty"` the field is only editable if it starts out empty when editing.
 
 * * *
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.2",
+  "version": "1.3.0",
   "name": "roadhouse",
   "description": "Angular Admin CRUD Tools",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.1",
+  "version": "1.2.2",
   "name": "roadhouse",
   "description": "Angular Admin CRUD Tools",
   "license": "MIT",

--- a/source/directives/rhField.js
+++ b/source/directives/rhField.js
@@ -80,6 +80,9 @@ module.exports = [ "$compile", "$filter", function ( $compile, $filter )
 
                 scope.startEmpty = !scope.model[ scope.def.key ];
 
+                var ngDisabled = 'ng-disabled="canEdit === false || canEdit === \'initial\' && !initial'
+                    + ' || canEdit === \'not-initial\' && initial || canEdit === \'empty\' && !startEmpty "';
+
                 var inputAttrs = 'data-ng-model="' + modelName + '" '
                     + ( scope.def.validate ? 'rh-valid="def.validate"' : "" )
                     + ( scope.def.changed ? 'ng-change="def.changed()"' : "" )
@@ -91,8 +94,7 @@ module.exports = [ "$compile", "$filter", function ( $compile, $filter )
                     + ( scope.def.uiMask ? 'ui-mask="' + scope.def.uiMask + '" ' : "" )
                     + ( pattern ? 'pattern="' + pattern + '" ' : "" )
                     + ( scope.def.required ? "required " : "" )
-                    + 'ng-disabled="canEdit === false || canEdit === \'initial\' && !initial'
-                    + ' || canEdit === \'empty\' && !startEmpty "'
+                    + ngDisabled
                     + ( scope.def.type === "date" ? "data-date-picker " : "" )
                     + " " + getDirectAttrs();
 
@@ -138,6 +140,7 @@ module.exports = [ "$compile", "$filter", function ( $compile, $filter )
                         + '  <button data-ng-repeat="option in def.options" type="button"'
                         + '     class="btn btn-default rh-{{ option.value === true ? \'true\' : option.value === false ? \'false\' : option.value | slugify }}"'
                         + '     data-ng-click="' + modelName + ' = option.value"'
+                        + ngDisabled
                         + '     data-ng-class="{ \'active\': ' + modelName + ' === option.value }">{{ option.name }}</button>'
                         + "</div>";
                     }
@@ -174,6 +177,12 @@ module.exports = [ "$compile", "$filter", function ( $compile, $filter )
                 }
             } );
             scope.$watch( "initial",  function ( newVal, oldVal ) {
+                if( newVal !== oldVal )
+                {
+                    render();
+                }
+            } );
+            scope.$watch( "not-initial",  function ( newVal, oldVal ) {
                 if( newVal !== oldVal )
                 {
                     render();

--- a/source/directives/rhField.js
+++ b/source/directives/rhField.js
@@ -8,7 +8,7 @@ module.exports = [ "$compile", "$filter", function ( $compile, $filter )
         scope: {
             def: "=rhDefinition",
             model: "=rhModel",
-            initial: "=rhInitial"
+            initial: "=?rhInitial"
         },
         link: function ( scope, element, attrs )
         {

--- a/source/directives/rhField.js
+++ b/source/directives/rhField.js
@@ -7,7 +7,8 @@ module.exports = [ "$compile", "$filter", function ( $compile, $filter )
     return {
         scope: {
             def: "=rhDefinition",
-            model: "=rhModel"
+            model: "=rhModel",
+            initial: "=rhInitial"
         },
         link: function ( scope, element, attrs )
         {
@@ -15,7 +16,7 @@ module.exports = [ "$compile", "$filter", function ( $compile, $filter )
             {
                 scope.def = scope.def || {};
                 scope.model = scope.model || {};
-                scope.initial = !!attrs.rhInitial;
+                scope.initial = !!scope.initial;
 
                 var getType = function ()
                 {
@@ -140,7 +141,7 @@ module.exports = [ "$compile", "$filter", function ( $compile, $filter )
                         + '  <button data-ng-repeat="option in def.options" type="button"'
                         + '     class="btn btn-default rh-{{ option.value === true ? \'true\' : option.value === false ? \'false\' : option.value | slugify }}"'
                         + '     data-ng-click="' + modelName + ' = option.value"'
-                        + ngDisabled
+                        + "     " + ngDisabled
                         + '     data-ng-class="{ \'active\': ' + modelName + ' === option.value }">{{ option.name }}</button>'
                         + "</div>";
                     }
@@ -177,12 +178,6 @@ module.exports = [ "$compile", "$filter", function ( $compile, $filter )
                 }
             } );
             scope.$watch( "initial",  function ( newVal, oldVal ) {
-                if( newVal !== oldVal )
-                {
-                    render();
-                }
-            } );
-            scope.$watch( "not-initial",  function ( newVal, oldVal ) {
                 if( newVal !== oldVal )
                 {
                     render();

--- a/test/harness.html
+++ b/test/harness.html
@@ -16,6 +16,12 @@
 
         <base href="/">
 
+        <style>
+        .alertify-logs {
+          z-index: 10000 !important;
+        }
+        </style>
+
     </head>
 
     <body>


### PR DESCRIPTION
This allows a fixed value to be set when an item is being created that is allowed to be edited later. There are a lot of options on `canEdit` now, it is possible more than one should be allowed in the future or that it would be simpler if the function that controlled editability had more context available to allow more to be handles within it. Considerations for a v2 likely.

@dmaloneycalu 