### PR TITLE
[UPDATE] Table List Item Customization, Form Delete show

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ But all these options are available:
         canCreate: Boolean | Function that returns Boolean | Object { max: Number },
         canEdit: Boolean | Function that returns Boolean,
         canDelete: Boolean | Function that returns Boolean,
-        showDelete: [FORM ONLY] Boolean | Function that returns Boolean,
-        showEditDelete: [TABLE ONLY] Boolean,
         editHeading: String,
         deleteHeading: String
     },
@@ -180,19 +178,21 @@ Whether the field can be edited. When set to `false` an `rh-field` will be disab
 
 #### `showDelete`
 
-*"Optional" Boolean* | Default: true
+*[Optional] "initial", "empty", Boolean, Function that returns Boolean* | Default: true
 
-**[Form Directive Only]** Optional boolean switch for hiding delete button in the
-form dialog.
+**[Form Directive Only]** Optional boolean or callback function switch for hiding
+delete button in the form dialog. For callback function scope.model is provided
+as argument.
 
 * * *
 
 #### `showEditDelete`
 
-*"Optional" Boolean* | Default: false
+*[Optional] "initial", "empty", Boolean, Function that returns Boolean* | Default: true
 
-**[Table Directive Only]** Optional boolean switch for hiding delete button in the
-edit dialog.
+**[Table Directive Only]** Optional boolean switch or callback function  for
+hiding delete button in the edit dialog. For callback function the corresponding
+table row item is provided as argument.
 
 * * *
 
@@ -312,7 +312,7 @@ Each of the directives in Roadhouse can be used individually, but to create a ty
     rh-on-create="list.create"
     rh-on-update="list.update"
     rh-on-delete="list.delete"
-    rh-hide-edit-delete="list.hideEditDelete"
+    rh-show-edit-delete="list.hideEditDelete"
     rh-can-edit-item="list.canEditItem"
     rh-can-delete-item="list.canDeleteItem"
     rh-loading="list.loading"></div>
@@ -330,8 +330,8 @@ Each of the directives in Roadhouse can be used individually, but to create a ty
 - `rh-on-create` is a callback function
 - `rh-on-update` is a callback function
 - `rh-on-delete` is a callback function
-- `rh-show-edit-delete` is a boolean to hide the delete button in the edit
-  dialog
+- `rh-show-edit-delete` is a boolean or callback function used for setting the
+visibility of the edit dialog delete button. Default is true.
 - `rh-can-edit-item` is a callback function that receives the corresponding
 item object as an argument and should return a boolean. Boolean result
 determines if the item edit button is shown for the row.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ But all these options are available:
         canCreate: Boolean | Function that returns Boolean | Object { max: Number },
         canEdit: Boolean | Function that returns Boolean,
         canDelete: Boolean | Function that returns Boolean,
+        showDelete: [FORM ONLY] Boolean | Function that returns Boolean,
+        showEditDelete: [TABLE ONLY] Boolean,
         editHeading: String,
         deleteHeading: String
     },
@@ -176,6 +178,40 @@ Whether the field can be edited. When set to `false` an `rh-field` will be disab
 
 * * *
 
+#### `showDelete`
+
+*"Optional" Boolean* | Default: true
+
+**[Form Directive Only]** Optional boolean switch for hiding delete button in the
+form dialog.
+
+* * *
+
+#### `showEditDelete`
+
+*"Optional" Boolean* | Default: false
+
+**[Table Directive Only]** Optional boolean switch for hiding delete button in the
+edit dialog.
+
+* * *
+
+#### `canEditItem`
+
+*"Optional" Function that returns Boolean* | Default: Function returning true
+
+**[Table Directive Only]** Optional filter function for selectively
+enabling/disabling which list items have edit capability.
+
+* * *
+
+#### `canDeleteItem`
+
+*"Optional" Function that returns Boolean* | Default: Function returning true
+
+**[Table Directive Only]** Optional filter function for selectively
+enabling/disabling which list items have delete option.
+
 #### `canViewList`
 
 *Boolean* | Default: true
@@ -276,6 +312,9 @@ Each of the directives in Roadhouse can be used individually, but to create a ty
     rh-on-create="list.create"
     rh-on-update="list.update"
     rh-on-delete="list.delete"
+    rh-hide-edit-delete="list.hideEditDelete"
+    rh-can-edit-item="list.canEditItem"
+    rh-can-delete-item="list.canDeleteItem"
     rh-loading="list.loading"></div>
 
 <div rh-paginator
@@ -291,6 +330,14 @@ Each of the directives in Roadhouse can be used individually, but to create a ty
 - `rh-on-create` is a callback function
 - `rh-on-update` is a callback function
 - `rh-on-delete` is a callback function
+- `rh-show-edit-delete` is a boolean to hide the delete button in the edit
+  dialog
+- `rh-can-edit-item` is a callback function that receives the corresponding
+item object as an argument and should return a boolean. Boolean result
+determines if the item edit button is shown for the row.
+- `rh-can-delete-item` is a callback function that receives the corresponding
+item object as an argument and should return a boolean. Boolean result
+determines if the delete button on the edit dialog is hidden.
 - `rh-loading` is a boolean to tell the table whether loading is in progress, this is important so the table knows whether records are loading or the list is loaded with no records as both statuses are displayed for the user
 - `rh-paginator-page-count` is the total number of pages
 - `rh-paginator-current-page` is the current page number
@@ -308,6 +355,7 @@ Each of the directives in Roadhouse can be used individually, but to create a ty
 ```js
 ctrl.list = [];
 ctrl.definition = {...};
+ctrl.showEditDelete = false;
 
 ctrl.getList = function ()
 {
@@ -329,6 +377,9 @@ ctrl.getList = function ()
 ctrl.create = function ( item ) { /* POST item to API */ };
 ctrl.update = function ( item ) { /* PUT item to API */ };
 ctrl.delete = function ( item ) { /* DELETE item from API */ };
+
+ctrl.canEditItem = function ( item ) { /* Retuen Boolean */ };
+ctrl.canDeleteItem = function ( item ) { /* Retuen Boolean */ };
 
 ctrl.getList(); // on load
 ```

--- a/source/directives/rhForm.js
+++ b/source/directives/rhForm.js
@@ -11,7 +11,8 @@ module.exports = [ "$compile", function ( $compile )
             delete: "=rhOnDelete",
             cancel: "=rhOnCancel",
             model: "=rhModel",
-            titleVisible: "=rhTitleVisible"
+            titleVisible: "=rhTitleVisible",
+            showDelete: "=?rhHideDelete"
         },
         link: function ( scope, element )
         {
@@ -74,7 +75,11 @@ module.exports = [ "$compile", function ( $compile )
                 } );
 
                 scope.formName = "rh" + ( scope.definition.meta.title || "" ).replace( /[^\w\d]*/g, "" ) + "Form";
-                scope.canDelete = scope.model.id && utils.runIfFunc( scope.definition.meta.canDelete ) !== false;
+                scope.canDelete = Boolean(
+                  utils.runIfFunc( scope.definition.meta.showDelete ) !== false &&
+                  scope.model.id &&
+                  utils.runIfFunc( scope.definition.meta.canDelete ) !== false
+                );
 
 
                 var form = '<form name="{{ formName }}" class="rh-form" data-ng-submit="saveClick( ' + scope.formName + ' )">'

--- a/source/directives/rhForm.js
+++ b/source/directives/rhForm.js
@@ -12,7 +12,7 @@ module.exports = [ "$compile", function ( $compile )
             cancel: "=rhOnCancel",
             model: "=rhModel",
             titleVisible: "=rhTitleVisible",
-            showDelete: "=?rhHideDelete"
+            showDelete: "=?rhShowDelete"
         },
         link: function ( scope, element )
         {
@@ -44,6 +44,17 @@ module.exports = [ "$compile", function ( $compile )
                         scope.save( scope.model );
                     }
                 };
+                scope.getShowDeleteState = function ()
+                {
+                    // NOTE: Maintain Default for Previous Implementation
+                    if ( !(typeof( scope.showDelete ) === 'boolean' || angular.isFunction( scope.showDelete )) )
+                    {
+                        return true;
+                    }
+                    return Boolean(
+                        angular.isFunction( scope.showDelete ) ? scope.showDelete( scope.model ) : scope.showDelete
+                    );
+                }
 
                 keys.forEach( function ( key )
                 {
@@ -76,7 +87,7 @@ module.exports = [ "$compile", function ( $compile )
 
                 scope.formName = "rh" + ( scope.definition.meta.title || "" ).replace( /[^\w\d]*/g, "" ) + "Form";
                 scope.canDelete = Boolean(
-                  utils.runIfFunc( scope.definition.meta.showDelete ) !== false &&
+                  scope.getShowDeleteState() &&
                   scope.model.id &&
                   utils.runIfFunc( scope.definition.meta.canDelete ) !== false
                 );

--- a/source/directives/rhTable.js
+++ b/source/directives/rhTable.js
@@ -27,7 +27,7 @@ function ( $compile, $rootScope, ngDialog, alertify )
             create: "=rhOnCreate",
             delete: "=rhOnDelete",
             loading: "=rhLoading",
-            showEditDelete: "=?rhHideEditDelete",
+            showEditDelete: "=?rhShowEditDelete",
             canEditItem: "=?rhCanEditItem",
             canDeleteItem: "=?rhCanDeleteItem",
         },
@@ -70,8 +70,6 @@ function ( $compile, $rootScope, ngDialog, alertify )
             var openDialog = function ( dialogScope )
             {
                 dialogScope.definition = scope.definition;
-                dialogScope.showDelete = scope.showEditDelete;
-
                 dialogScope.cancel = function ()
                 {
                     ngDialog.closeAll();
@@ -91,6 +89,7 @@ function ( $compile, $rootScope, ngDialog, alertify )
             {
                 var dialogScope = scope.$new();
                 dialogScope.item = angular.copy( item );
+                dialogScope.showDelete = scope.showEditDelete;
                 dialogScope.save = function ( item )
                 {
                     scope.update( item )

--- a/source/directives/rhTable.js
+++ b/source/directives/rhTable.js
@@ -38,8 +38,8 @@ function ( $compile, $rootScope, ngDialog, alertify )
                 scope.loading = true;
             }
 
-            scope.canEditItem = angular.isFunction(scope.canEditItem) ? scope.canEditItem : function() { return true };
-            scope.canDeleteItem = angular.isFunction(scope.canDeleteItem) ? scope.canDeleteItem : function() { return true };
+            scope.canEditItem = angular.isFunction(scope.canEditItem) ? scope.canEditItem : function() { return true; };
+            scope.canDeleteItem = angular.isFunction(scope.canDeleteItem) ? scope.canDeleteItem : function() { return true; };
 
             var getIndexById = function ( id )
             {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
* Create table attribute `canEditItem` for per table item edit control
* Create table attribute `canDeleteItem` for per table item delete control
* Create table attribute `showEditDelete` hiding dialog edit delete button
* Create form attribute `showDelete` hiding dialog delete button
* Attach Table List Item index to each table row for targeted styling
* Update (README) documentation


## Motivation and Context
__Why is this change required? What problem does it solve?__
Previous Roadhouse Plugin state was limited in terms of customization. This update is meant to expanded customization capability.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* Basic server API requests verified in local development environment
* Run existing specs against local development environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- - -

@vokal/web